### PR TITLE
Adicionar axios globalmente

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,8 +1,11 @@
 const express = require("express");
 const bodyParser = require("body-parser");
+const cors = require("cors");
 const users = require("./routes/users");
 
 const app = express();
+
+app.use(cors());
 
 app.use(bodyParser.json());
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "lowdb": "^1.0.0",
     "md5": "^2.2.1",

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
-import Vue from 'vue';
-import Vuelidate from 'vuelidate';
-import App from './App.vue';
-import router from './router';
-import store from './store';
-import '@fortawesome/fontawesome-free/css/all.css';
-import '@fortawesome/fontawesome-free/js/all.js';
+import Vue from "vue";
+import Vuelidate from "vuelidate";
+import App from "./App.vue";
+import router from "./router";
+import store from "./store";
+import "@fortawesome/fontawesome-free/css/all.css";
+import "@fortawesome/fontawesome-free/js/all.js";
+import "./plugins/axios";
 
 Vue.use(Vuelidate);
 Vue.config.productionTip = false;
@@ -14,5 +15,5 @@ Vue.use(Vuelidate);
 new Vue({
   router,
   store,
-  render: (h) => h(App),
-}).$mount('#app');
+  render: h => h(App)
+}).$mount("#app");

--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -1,0 +1,10 @@
+import Vue from "vue";
+import axios from "axios";
+
+Vue.use({
+  install(Vue) {
+    Vue.prototype.$http = axios.create({
+      baseURL: "http://localhost:3000"
+    });
+  }
+});


### PR DESCRIPTION
Inserindo a chamada da API globalmente, facilitando assim o uso no front end, sem precisar ficar importando em todos os componentes